### PR TITLE
FIX: Don't call translation functions for strings

### DIFF
--- a/models/auth0.py
+++ b/models/auth0.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from odoo import fields, models, _
+from odoo import fields, models
 import requests
 
 from odoo.exceptions import UserError
@@ -9,8 +9,8 @@ import json
 class Auth0(models.Model):
     _inherit = 'auth.oauth.provider'
 
-    client_secret = fields.Char(string=_('Client Secret'))
-    jwt_secret = fields.Char(string=_('JWT Secret'))
+    client_secret = fields.Char(string='Client Secret')
+    jwt_secret = fields.Char(string='JWT Secret')
 
     def get_auth0_oauth_provider(self):
         return self.env['auth.oauth.provider'].sudo().search([


### PR DESCRIPTION
There is no need to add _() on field strings as the strings will always be exportable and translatable, also without _()
You only need `_()` for `Warnings` or any message that is shown in dialogs for example.